### PR TITLE
Support inline sourcemap files and packaged files.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,10 @@
-var _ = require("lodash-node"),
+var path = require("path"),
+	_ = require("lodash-node"),
 	Promise = require("bluebird"),
+	sourcemap = require("source-map")
+	convert = require('convert-source-map'),
 	fs = Promise.promisifyAll(require("fs")),
-	path = require("path"),
-	lcovParse = Promise.promisify(require("lcov-parse")),
-	sourcemap = require("source-map");
+	lcovParse = Promise.promisify(require("lcov-parse"));
 
 var File = require("./File");
 
@@ -26,6 +27,11 @@ function getOutputLcov(files, sourceDir) {
 	sourceDir = sourceDir || process.cwd();
 
 	return Promise.all(_.map(files, function (file) {
+
+		//check if used package tool like webpack or otherwise
+		if (file.path.match(/\.\/[A-z]*:\/\/\//g)) {
+			file.path = file.path.split(/(\.\/[A-z]*:\/\/\/)(.*)/g)[2];
+		}
 		return new Promise(function (resolve) {
 			fs.exists(path.resolve(sourceDir, file.path), function (exists) {
 				if (!exists) {
@@ -147,11 +153,21 @@ function getSourcemapsData(sourcemaps) {
 	}
 
 	return Promise.props(_.mapValues(sourcemaps, function (file) {
-		return fs.readFileAsync(file).then(function (file) {
-			return file.toString();
-		}).then(function (content) {
-			return new sourcemap.SourceMapConsumer(content);
-		});
+
+		//Accept non .map files, include the ability to use commented out source
+		if(path.extname(file.path) === '.map') {
+			return fs.readFileAsync(file, 'utf8').then(function (file) {
+				return file.toString();
+			}).then(function (content) {
+				return new sourcemap.SourceMapConsumer(content);
+			});
+		} else {
+			return fs.readFileAsync(file, 'utf8').then(function (file) {
+				return convert.fromSource(file, true).toObject();
+			}).then(function (content) {
+				return new sourcemap.SourceMapConsumer(content);
+			});
+		}
 	}));
 }
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"bluebird": "^2.9.21",
 		"lcov-parse": "0.0.9",
 		"lodash-node": "^3.6.0",
-		"source-map": "^0.4.2"
+		"source-map": "^0.4.2",
+        "convert-source-map": "^1.2.0"
 	}
 }


### PR DESCRIPTION
This commit adds the support for inline source map files. It also adds a parse to check if someone if the sourcemap files where packaged via webpack or another similar packaging tool by checking if the filepath begins with `./webpack:////` or similar. 